### PR TITLE
Handle insert conflict on simulator eligibility

### DIFF
--- a/server/scripts/create-test-data.sql
+++ b/server/scripts/create-test-data.sql
@@ -1,0 +1,88 @@
+-- =====================================================
+-- CRÉATION DE DONNÉES DE TEST POUR LA MIGRATION
+-- Date: 2025-01-30
+-- =====================================================
+
+-- 1. Créer une session de simulateur de test
+INSERT INTO "SimulatorSession" (
+    session_token,
+    status,
+    created_at,
+    updated_at,
+    metadata
+) VALUES (
+    'SESSION_TOKEN_TEST',
+    'completed',
+    NOW(),
+    NOW(),
+    jsonb_build_object(
+        'test_data', true,
+        'description', 'Session de test pour migration'
+    )
+) ON CONFLICT (session_token) DO NOTHING;
+
+-- 2. Récupérer l'ID de la session créée
+DO $$
+DECLARE
+    v_session_id uuid;
+BEGIN
+    SELECT id INTO v_session_id 
+    FROM "SimulatorSession" 
+    WHERE session_token = 'SESSION_TOKEN_TEST';
+    
+    -- Vérifier si la session existe
+    IF v_session_id IS NULL THEN
+        RAISE EXCEPTION 'Session non trouvée';
+    END IF;
+    
+    -- 3. Supprimer les éligibilités existantes pour éviter les doublons
+    DELETE FROM "SimulatorEligibility" WHERE session_id = v_session_id;
+    
+    -- 4. Créer des éligibilités de test
+    INSERT INTO "SimulatorEligibility" (
+        session_id,
+        produit_id,
+        eligibility_score,
+        estimated_savings,
+        confidence_level,
+        recommendations,
+        calculation_details,
+        created_at
+    ) VALUES 
+    (
+        v_session_id,
+        'cee-product', -- ID du produit CEE
+        85.5,
+        2500.00,
+        0.92,
+        ARRAY['Installation recommandée', 'Économies importantes'],
+        jsonb_build_object('method', 'standard_calculation', 'factors', jsonb_build_array('surface', 'isolation')),
+        NOW()
+    ),
+    (
+        v_session_id,
+        'cir-product', -- ID du produit CIR
+        72.3,
+        1800.00,
+        0.88,
+        ARRAY['Rénovation conseillée', 'Amélioration énergétique'],
+        jsonb_build_object('method', 'cir_calculation', 'factors', jsonb_build_array('batiment', 'usage')),
+        NOW()
+    );
+    
+    RAISE NOTICE 'Données de test créées pour la session: %', v_session_id;
+END $$;
+
+-- 5. Vérifier les données créées
+SELECT 
+    'Données de test créées' as section,
+    COUNT(*) as total_sessions
+FROM "SimulatorSession" 
+WHERE session_token = 'SESSION_TOKEN_TEST';
+
+SELECT 
+    'Éligibilités créées' as section,
+    COUNT(*) as total_eligibilities
+FROM "SimulatorEligibility" se
+JOIN "SimulatorSession" ss ON se.session_id = ss.id
+WHERE ss.session_token = 'SESSION_TOKEN_TEST';


### PR DESCRIPTION
Make `create-test-data.sql` reliable by replacing `ON CONFLICT` with `DELETE` before `INSERT` for `SimulatorEligibility`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d7ea5e9-6010-4287-8189-21fabc12eab8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d7ea5e9-6010-4287-8189-21fabc12eab8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>